### PR TITLE
Extending deadlines

### DIFF
--- a/_includes/dates.md
+++ b/_includes/dates.md
@@ -1,4 +1,4 @@
-* Abstract submission: 4 May 2015
-* Paper submission:  11 May 2015
+* Abstract submission **Updated**: ~~4~~ 11 May 2015
+* Paper submission **Updated**:  ~~11~~ 18 May 2015
 * Author notification:     3 July 2015
 * Camera-ready submission:  1 August 2015

--- a/cfp/wrap-2015-cfp.txt
+++ b/cfp/wrap-2015-cfp.txt
@@ -47,8 +47,8 @@ Work which examines similar topics will also be considered for inclusion
 in the workshop.
 
 Dates:
-- Abstract submission: 4 May 2015
-- Paper submission: 11 May 2015
+- Abstract submission **Updated**: ~~4~~ 11 May 2015
+- Paper submission **Updated**: ~~11~~ 18 May 2015
 - Author notification: 3 July 2015
 - Camera-ready submission: 1 August 2015
 - Conference: September 8th - September 11th, 2015


### PR DESCRIPTION
Both the abstract and paper deadlines are being pushed back one week, starting with the CFP.
